### PR TITLE
Do not assign motion provider automatically if device uniq is empty

### DIFF
--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -479,7 +479,7 @@ class UDPServer:
                             for dd in evdev_devices: # try to automagically identify correct IMU for individual Joy-Cons and Pro Controller
                                 if dd.uniq == d.uniq and dd != d and dd.uniq != "": # combined Joy-Cons have blank uniqs and should not be assigned to any random evdev device
                                     motion_d = dd
-                                    print("Using " + motion_d.name + " as motion provider " + d.name)
+                                    print("Using " + motion_d.name + " as motion provider for " + d.name)
                                     break
                             
                             if motion_d == None:

--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -477,9 +477,9 @@ class UDPServer:
                             motion_d = None
 
                             for dd in evdev_devices: # try to automagically identify correct IMU for individual Joy-Cons and Pro Controller
-                                if dd.uniq == d.uniq and dd != d and dd.uniq != "": # combined Joy-Cons have blank uniqs
+                                if dd.uniq == d.uniq and dd != d and dd.uniq != "": # combined Joy-Cons have blank uniqs and should not be assigned to any random evdev device
                                     motion_d = dd
-                                    print("Using " + motion_d.name + " as motion provider")
+                                    print("Using " + motion_d.name + " as motion provider " + d.name)
                                     break
                             
                             if motion_d == None:
@@ -487,7 +487,7 @@ class UDPServer:
                                 for i, dd in enumerate(evdev_devices):
                                     print(str(i) + " " + dd.name + " " + dd.uniq)
                                 motion_d = evdev_devices[int(input(""))]
-                                print("Using " + motion_d.name + " as motion provider")
+                                print("Using " + motion_d.name + " as motion provider for " + d.name)
 
                             for i in range(4):
                                 if self.slots[i] == None:

--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -471,14 +471,15 @@ class UDPServer:
                     d.name == "Nintendo Switch Right Joy-Con" or \
                     d.name == "Nintendo Switch Pro Controller" or \
                     d.name == "Nintendo Switch Combined Joy-Cons":
-                        found = True if any(my_device.device == d for my_device in self.slots if my_device != None) else False
+                        found = any(my_device.device == d for my_device in self.slots if my_device != None)
 
                         if not found:
                             motion_d = None
 
-                            for dd in evdev_devices:
-                                if dd.uniq == d.uniq and dd != d:
+                            for dd in evdev_devices: # try to automagically identify correct IMU for individual Joy-Cons and Pro Controller
+                                if dd.uniq == d.uniq and dd != d and dd.uniq != "": # combined Joy-Cons have blank uniqs
                                     motion_d = dd
+                                    print("Using " + motion_d.name + " as motion provider")
                                     break
                             
                             if motion_d == None:
@@ -486,6 +487,7 @@ class UDPServer:
                                 for i, dd in enumerate(evdev_devices):
                                     print(str(i) + " " + dd.name + " " + dd.uniq)
                                 motion_d = evdev_devices[int(input(""))]
+                                print("Using " + motion_d.name + " as motion provider")
 
                             for i in range(4):
                                 if self.slots[i] == None:


### PR DESCRIPTION
Resolves #11. In addition, when a motion provider is selected, the name of that device is printed as well.