### PR TITLE
Use time_ns() instead of time() to generate timestamp

### DIFF
--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -441,7 +441,7 @@ class UDPServer:
             0x00, 0x00,  # trackpad second y
         ])
 
-        data.extend(bytes(struct.pack('<Q', int(time.time() * 10**6))))
+        data.extend(bytes(struct.pack('<Q', time.time_ns() // 1000)))
 
         if device.motion_device != None:
             sensors = [


### PR DESCRIPTION
`time_ns` should give a more accurate timestamp than `time`. See [PEP 564](https://www.python.org/dev/peps/pep-0564/) for more details