### PR TITLE
Add function to detect the led status of a device

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 evdev
+pyudev
 asyncio
 dbus-python
 argparse


### PR DESCRIPTION
I found a simple-ish way to detect the led status of a device, using the pyudev module.
This has the benefit of using a defined API, instead of reading directly from hardcoded paths in `/sys`
The function returns a dictionary describing the led names and status. example:
`{'player1': '1', 'player2': '0', 'player3': '0', 'player4': '0'} # left joy-con`
`{'home': '0', 'player1': '1', 'player2': '0', 'player3': '0', 'player4': '0'} # right joy-con`
[pyudev docs](https://pyudev.readthedocs.io/en/latest/api/pyudev.html#module-pyudev)
Related issue: #27
