### PR TITLE
Improve print_slots alignment and battery symbol

### DIFF
--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -690,9 +690,9 @@ class UDPServer:
     
     def print_slots(self):
         print(colored("======================== Slots ========================", attrs=["bold"]))
-        
-        print (colored("{:<14} {:<12} {:<12} {:<12} {:<12}", attrs=["bold"])
-            .format("Device", "LED status", "Battery Lv", "Motion Dev", "MAC Addr"))
+
+        print (colored("{:<14} {:<12} {:<12} {:<12}", attrs=["bold"])
+            .format("Device", "LED status", "Battery Lv", "MAC Addr"))
 
         for i, slot in enumerate(self.slots):
             if not slot:
@@ -715,20 +715,16 @@ class UDPServer:
 
                 if not leds:
                     leds = "?"
-                
+
                 if slot.battery_level:
-                    battery = F"{str(slot.battery_level)} {chr(ord('▁') + int(slot.battery_level / 10) - 1)}"
+                    battery = F"{str(slot.battery_level)} {chr(ord('▁') + int(slot.battery_level * 7 / 100))}"
                 else:
                     battery = "❌"
-
-                if slot.motion_device:
-                    motion_d = "✔️"
-                else:
-                    motion_d = "❌"
                 
                 mac = slot.serial
 
-                print(F'{device:<15} {colored(F"{leds:<12}", "green")} {colored(F"{battery:<12}", "green")} {motion_d:<13} {mac:<12}')
+                # print device after calculating alignment because the gamepad symbols cause alignment errors
+                print(F'{"":<14} {colored(F"{leds:<12}", "green")} {colored(F"{battery:<12}", "green")} {mac:<12}\r{device}')
 
         print(colored("=======================================================", attrs=["bold"]))
 


### PR DESCRIPTION
I noticed that the characters used for the battery status fill up from 0 to 7, and then start to thin out:
![percentages](https://user-images.githubusercontent.com/71563441/104107188-1fc47080-52c3-11eb-9fb9-c92db20105f6.png)
So the range for the battery symbol should be 0-7 instead of 0-10
I also fixed an alignment issue related to the gamepad symbols. To fix it, `device` is omitted from the alignment calculation, and only printed later using carriage return.
Here's my output before & after:
![old](https://user-images.githubusercontent.com/71563441/104107390-69fa2180-52c4-11eb-9a3e-518471406607.png)
![new](https://user-images.githubusercontent.com/71563441/104107395-72eaf300-52c4-11eb-8d72-d3652c2bdfbd.png)
I removed the motion device column, as I don't think it has any relevance now.