### PR TITLE
Added a verification for keyboards

### DIFF
--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -69,6 +69,8 @@ def get_player_id(device):
     if not player:
         try:
             player = len(device.leds())
+            if any([led[0] == 'numlock' for led in leds]):
+                player = 0
         except AttributeError:
             pass
 


### PR DESCRIPTION
It forced me to launch joycond-cemuhook before linking the first joycon
By checking that none of the leds is called numlock, it works