### PR TITLE
Don't call `Refresh` on UPower devices

### DIFF
--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -275,7 +275,6 @@ class SwitchDevice:
             dev = bus.get_object('org.freedesktop.UPower', device)
 
             dbus_interface = dbus.Interface(dev, 'org.freedesktop.UPower.Device')
-            dbus_interface.Refresh()
 
             dbus_properties_interface = dbus.Interface(dev, 'org.freedesktop.DBus.Properties')
             properties = dbus_properties_interface.GetAll("org.freedesktop.UPower.Device")
@@ -291,7 +290,6 @@ class SwitchDevice:
         print_verbose("Battery level reading thread started")
         try:
             while self.dbus_interface != None:
-                self.dbus_interface.Refresh()
                 properties = self.dbus_properties_interface.GetAll("org.freedesktop.UPower.Device")
                 if properties["Percentage"] != self.battery:
                     print_verbose("Battery level changed")


### PR DESCRIPTION
As mentioned in #63, removing those two lines (to be compatible with the most recent UPower release) did not seem to affect program functionality, so I don't know why they were there