### PR TITLE
Support statically built hid_nintendo

### DIFF
--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -779,8 +779,14 @@ def main():
     hid_nintendo_loaded = process.returncode
 
     if hid_nintendo_loaded == 1:
-        print("Seems like hid_nintendo is not loaded. Load it with 'sudo modprobe hid_nintendo'.")
-        exit()
+        # Check if hid_nintendo is statically built into the kernel
+        process = subprocess.Popen(["/bin/sh", "-c", 'cat /lib/modules/$(uname -r)/modules.builtin | grep hid-nintendo'], stdout=subprocess.DEVNULL)
+        process.communicate()
+        hid_nintendo_loaded = process.returncode
+
+        if hid_nintendo_loaded == 1:
+            print("Seems like hid_nintendo is not loaded. Load it with 'sudo modprobe hid_nintendo'.")
+            exit()
 
     stop_event = threading.Event()
 


### PR DESCRIPTION
My kernel has `hid_nintendo` built-in instead of having it as a module. Therefore, `lsmod` fails to find it and the script reports `hid_nintendo` as not loaded.

https://github.com/joaorb64/joycond-cemuhook/blob/master/joycond-cemuhook.py#L777

This PR adds another check for built-in kernel modules.
Tested on Cemu