### PR TITLE
Consider hid-nx as kernel module name

### DIFF
--- a/joycond-cemuhook.py
+++ b/joycond-cemuhook.py
@@ -764,28 +764,28 @@ args = parser.parse_args()
 
 
 def main():
-    # Check if hid_nintendo module is installed
-    process = subprocess.Popen(["modinfo", "hid_nintendo"], stdout=subprocess.DEVNULL)
+    # Check if hid_nx module is installed
+    process = subprocess.Popen(["modinfo", "hid_nx"], stdout=subprocess.DEVNULL)
     process.communicate()
-    hid_nintendo_installed = process.returncode
+    hid_nx_installed = process.returncode
 
-    if hid_nintendo_installed == 1:
-        print("Seems like hid_nintendo is not installed.")
+    if hid_nx_installed == 1:
+        print("Seems like hid_nx is not installed.")
         exit()
 
-    # Check if hid_nintendo module is loaded
-    process = subprocess.Popen(["/bin/sh", "-c", 'lsmod | grep hid_nintendo'], stdout=subprocess.DEVNULL)
+    # Check if hid_nx module is loaded
+    process = subprocess.Popen(["/bin/sh", "-c", 'lsmod | grep hid_nx'], stdout=subprocess.DEVNULL)
     process.communicate()
-    hid_nintendo_loaded = process.returncode
+    hid_nx_loaded = process.returncode
 
-    if hid_nintendo_loaded == 1:
-        # Check if hid_nintendo is statically built into the kernel
-        process = subprocess.Popen(["/bin/sh", "-c", 'cat /lib/modules/$(uname -r)/modules.builtin | grep hid-nintendo'], stdout=subprocess.DEVNULL)
+    if hid_nx_loaded == 1:
+        # Check if hid_nx is statically built into the kernel
+        process = subprocess.Popen(["/bin/sh", "-c", 'cat /lib/modules/$(uname -r)/modules.builtin | grep hid-nx'], stdout=subprocess.DEVNULL)
         process.communicate()
-        hid_nintendo_loaded = process.returncode
+        hid_nx_loaded = process.returncode
 
-        if hid_nintendo_loaded == 1:
-            print("Seems like hid_nintendo is not loaded. Load it with 'sudo modprobe hid_nintendo'.")
+        if hid_nx_loaded == 1:
+            print("Seems like hid_nx is not loaded. Load it with 'sudo modprobe hid_nx'.")
             exit()
 
     stop_event = threading.Event()


### PR DESCRIPTION
This PR adds support for the alternative kernel module [hid-nx](https://github.com/emilyst/hid-nx-dkms). This change is backward compatible, support for `hid-nintendo` remains untouched.

Imports are unchanged, just sorted.

References #71