### PR TITLE
argparse is built into python 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   "pyudev",
   "asyncio",
   "dbus-python",
-  "argparse",
   "termcolor"
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Remove unnecessary dependency