### PR TITLE
fix: asyncio is a built-in python module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
 dependencies = [
   "evdev",
   "pyudev",
-  "asyncio",
   "dbus-python",
   "termcolor"
 ]


### PR DESCRIPTION
Since Python 3.7 I think or some other version, this module is built-in.