### PR TITLE
Change kernel module error to warning

### DIFF
--- a/src/joycond_cemuhook/__init__.py
+++ b/src/joycond_cemuhook/__init__.py
@@ -813,12 +813,11 @@ def main():
 
     if not check_modules(module_names):
         message = os.linesep.join([
-                      "Error: A required kernel module is missing.",
+                      "Warning: A required kernel module is missing.",
                       f"  Supported modules: {module_names}",
                       "  To load a module, try: sudo modprobe <module_name>",
                       "  Enable verbose logging for details."])
         print(message)
-        exit(1)
 
     stop_event = threading.Event()
 


### PR DESCRIPTION
Some more recent versions of the Linux kernel have [hid_nintendo built in](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/hid/hid-nintendo.c?h=v6.6.8), and quitting completely when it can't be found makes it tough for people with newer kernels to run this program without installing an unnecessary module.
Please edit this request if necessary, I didn't really look through the error/warning protocols here