### PR TITLE
Add new alias

### DIFF
--- a/src/joycond_cemuhook/__init__.py
+++ b/src/joycond_cemuhook/__init__.py
@@ -33,6 +33,7 @@ DEVICE_ALIASES = {
     "Joy-Con (R)":                       "Nintendo Switch Right Joy-Con",
     "Pro Controller":                    "Nintendo Switch Pro Controller",
     "Nintendo Co., Ltd. Pro Controller": "Nintendo Switch Pro Controller",
+    "Nintendo.Co.Ltd. Pro Controller":   "Nintendo Switch Pro Controller",
 }
 
 


### PR DESCRIPTION
  I have a 8BitDo Pro 2 controller that can emulate a Nintendo Switch Pro Controller. In my system it is detected as
  `Nintendo.Co.Ltd. Pro Controller` which was not a recognized alias and resulted in the controller being ignored.